### PR TITLE
add PostgreSQL example

### DIFF
--- a/examples/docker-compose.postgres.yaml
+++ b/examples/docker-compose.postgres.yaml
@@ -19,7 +19,7 @@ services:
       POSTGRES_USER: baikal
       POSTGRES_PASSWORD: ilovecookies
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres"]
+      test: ["CMD", "pg_isready", "-U", "baikal"]
     volumes:
       - db:/var/lib/postgresql
 

--- a/examples/docker-compose.postgres.yaml
+++ b/examples/docker-compose.postgres.yaml
@@ -1,0 +1,29 @@
+# Docker Compose file for a Baikal server with PostgreSQL 18
+
+version: "2"
+services:
+  baikal:
+    image: ghcr.io/aalmenar/baikal:nginx
+    restart: always
+    ports:
+      - "80:80"
+    volumes:
+      - config:/var/www/baikal/config
+      - data:/var/www/baikal/Specific
+
+  db:
+    image: postgres:18
+    restart: always
+    environment:
+      POSTGRES_DB: baikal
+      POSTGRES_USER: baikal
+      POSTGRES_PASSWORD: ilovecookies
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+    volumes:
+      - db:/var/lib/postgresql
+
+volumes:
+  config:
+  data:
+  db:


### PR DESCRIPTION
Since version 0.11.1, there is support for PostgreSQL, so an example docker-compose.yml has been added.