### PR TITLE
Adapt for rootless use

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -34,7 +34,7 @@ jobs:
         run: docker build -f ${{ inputs.dockerfile }}.dockerfile -t baikal-image .
 
       - name: Start Baikal container
-        run: docker run --rm -dp 80:80 --name ${{ inputs.dockerfile }} baikal-image
+        run: docker run --rm -dp 8080:8080 --name ${{ inputs.dockerfile }} baikal-image
 
       - name: Run Cypress tests
         run: npm run test
@@ -76,7 +76,7 @@ jobs:
         working-directory: cypress/fixtures
         run: |
           docker build -t mail-server -f mail-server.dockerfile .
-          docker run --rm -d --name mail-server -p 8025:8025 -p 8080:8080 mail-server
+          docker run --rm -d --name mail-server -p 8025:8025 -p 8081:8081 mail-server
 
       - name: Start Baikal container with MSMTP configuration
         env:
@@ -86,7 +86,7 @@ jobs:
             port    8025
             from    baikal@example.com
         run: |
-          docker run --rm --detach -p 80:80 -e MSMTPRC="$MSMTPRC" --link mail-server --name baikal baikal-image
+          docker run --rm --detach -p 8080:8080 -e MSMTPRC="$MSMTPRC" --link mail-server --name baikal baikal-image
           docker cp ${{ github.workspace }}/cypress/fixtures/mail-test.php baikal:/var/www/baikal/html/
 
       - name: Run Cypress tests incl. MSMTP

--- a/cypress/e2e/create-baikal-instance.cy.ts
+++ b/cypress/e2e/create-baikal-instance.cy.ts
@@ -2,7 +2,7 @@ describe("Create Baikal instance", () => {
   const adminCredentials = "ilovecookies";
 
   it("Should initialise Baikal", () => {
-    cy.visit("localhost");
+    cy.visit("localhost:8080");
 
     cy.get("#overview > h1").should(
       "have.text",
@@ -26,7 +26,7 @@ describe("Create Baikal instance", () => {
   });
 
   it("Should sign in as administrator", () => {
-    cy.visit("localhost/admin");
+    cy.visit("localhost:8080/admin");
 
     cy.get("input[name='password']").type(adminCredentials);
     cy.get("button[type='submit']").should("have.text", "Authenticate").click();

--- a/cypress/e2e/expose-php.cy.ts
+++ b/cypress/e2e/expose-php.cy.ts
@@ -2,7 +2,7 @@
 // See https://github.com/ckulka/baikal-docker/issues/111
 describe("Hidden PHP version header (#111)", () => {
   it("Should not expose PHP version", () => {
-    cy.request("localhost").should((response) => {
+    cy.request("localhost:8080").should((response) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       expect(response.headers["x-powered-by"], "HTTP header 'x-powered-by'").to
         .be.undefined;

--- a/cypress/e2e/send-mail-with-php.msmtp.cy.ts
+++ b/cypress/e2e/send-mail-with-php.msmtp.cy.ts
@@ -1,10 +1,10 @@
 describe("Send mail with PHP", () => {
   it("Should send an email with PHP", () => {
     // Send email through PHP (response of mail-test.php is the email subject)
-    cy.request("localhost/mail-test.php").then((response) => {
+    cy.request("localhost:8080/mail-test.php").then((response) => {
       // Verify that the email arrived
       cy.request({
-        url: "localhost:8080/mail",
+        url: "localhost:8081/mail",
         qs: {
           subject: response.body,
         },

--- a/cypress/fixtures/mail_server.py
+++ b/cypress/fixtures/mail_server.py
@@ -33,7 +33,7 @@ async def start_api(loop):
     app.add_routes([web.get('/mail', handle)])
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, '0.0.0.0', 8080)
+    site = web.TCPSite(runner, '0.0.0.0', 8081)
     await site.start()
 
 # Retrun the messages by subject

--- a/docs/unraid-installation-guide.md
+++ b/docs/unraid-installation-guide.md
@@ -34,7 +34,7 @@ With that in mind, the installation of Baikal is rather simple once you have the
 
 1. Set your _Icon URL_ to <https://raw.githubusercontent.com/sabre-io/sabre.io/master/source/img/baikal.png> (Baikal logo from the official maintainers).
 
-1. Set your _WebUI_ to `http://[IP]:[PORT:80]/`
+1. Set your _WebUI_ to `http://[IP]:[PORT:8080]/`
 
    Change this to whatever suits your local server port requirements - see below.
 
@@ -68,11 +68,11 @@ With that in mind, the installation of Baikal is rather simple once you have the
 
 1. Now add in a _port_ with
    - _Name_ is `Port`
-   - _Container Port_ is `80`
-   - _Host Port_ is `80` (change to the port where you want to expose Baikal over HTTP on your local server)
-   - _Default Value_ is `80` (see above)
+   - _Container Port_ is `8080`
+   - _Host Port_ is `8080` (change to the port where you want to expose Baikal over HTTP on your local server)
+   - _Default Value_ is `8080` (see above)
    - _Connection Type_ is `TCP`
-   - _Description_ is `Container Port: 80`
+   - _Description_ is `Container Port: 8080`
 
 1. Click _Apply_ to download and install the container.
 

--- a/examples/docker-compose.custom-storage-location.yaml
+++ b/examples/docker-compose.custom-storage-location.yaml
@@ -6,7 +6,7 @@ services:
     image: ghcr.io/aalmenar/baikal:nginx
     restart: always
     ports:
-      - "80:80"
+      - "8080:8080"
     volumes:
       - data:/var/www/baikal/Specific
       - config:/var/www/baikal/config

--- a/examples/docker-compose.email-gmail.yaml
+++ b/examples/docker-compose.email-gmail.yaml
@@ -19,7 +19,7 @@ services:
         user           <user>
         password       <password>
     ports:
-      - "80:80"
+      - "8080:8080"
     volumes:
       - config:/var/www/baikal/config
       - data:/var/www/baikal/Specific

--- a/examples/docker-compose.email.yaml
+++ b/examples/docker-compose.email.yaml
@@ -19,7 +19,7 @@ services:
         user           <user>
         password       <password>
     ports:
-      - "80:80"
+      - "8080:8080"
     volumes:
       - config:/var/www/baikal/config
       - data:/var/www/baikal/Specific

--- a/examples/docker-compose.localvolumes.yaml
+++ b/examples/docker-compose.localvolumes.yaml
@@ -13,7 +13,7 @@ services:
     image: ghcr.io/aalmenar/baikal:nginx
     restart: always
     ports:
-      - "80:80"
+      - "8080:8080"
     volumes:
       - ./config:/var/www/baikal/config
       - ./Specific:/var/www/baikal/Specific

--- a/examples/docker-compose.mariadb.yaml
+++ b/examples/docker-compose.mariadb.yaml
@@ -7,7 +7,7 @@ services:
     image: ghcr.io/aalmenar/baikal:nginx
     restart: always
     ports:
-      - "80:80"
+      - "8080:8080"
     volumes:
       - config:/var/www/baikal/config
       - data:/var/www/baikal/Specific

--- a/examples/docker-compose.ssl.yaml
+++ b/examples/docker-compose.ssl.yaml
@@ -44,7 +44,7 @@ services:
       # See https://doc.traefik.io/traefik/v2.10/observability/access-logs/
       - --accesslog
       # See https://doc.traefik.io/traefik/v2.10/routing/entrypoints/#redirection
-      - --entrypoints.web.address=:8080
+      - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
       - --entrypoints.web.http.redirections.entryPoint.to=websecure
       - --entrypoints.web.http.redirections.entryPoint.scheme=https

--- a/examples/docker-compose.ssl.yaml
+++ b/examples/docker-compose.ssl.yaml
@@ -21,6 +21,7 @@ services:
       traefik.http.middlewares.baikal-dav.redirectregex.regex: https://(.*)/.well-known/(card|cal)dav
       traefik.http.middlewares.baikal-dav.redirectregex.replacement: https://$$1/dav.php/
       traefik.http.middlewares.baikal-dav.redirectregex.permanent: true
+      traefik.http.services.baikal.loadbalancer.server.port: "8080"
     volumes:
       - config:/var/www/baikal/config
       - data:/var/www/baikal/Specific
@@ -43,7 +44,7 @@ services:
       # See https://doc.traefik.io/traefik/v2.10/observability/access-logs/
       - --accesslog
       # See https://doc.traefik.io/traefik/v2.10/routing/entrypoints/#redirection
-      - --entrypoints.web.address=:80
+      - --entrypoints.web.address=:8080
       - --entrypoints.websecure.address=:443
       - --entrypoints.web.http.redirections.entryPoint.to=websecure
       - --entrypoints.web.http.redirections.entryPoint.scheme=https

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     image: ghcr.io/aalmenar/baikal:nginx
     restart: always
     ports:
-      - "80:80"
+      - "8080:8080"
     volumes:
       - config:/var/www/baikal/config
       - data:/var/www/baikal/Specific

--- a/files/docker-entrypoint.d/nginx/40-disable-nginx-ipv6-if-unsupported.sh
+++ b/files/docker-entrypoint.d/nginx/40-disable-nginx-ipv6-if-unsupported.sh
@@ -10,5 +10,5 @@ ME=$(basename $0)
 # Added to resolve https://github.com/ckulka/baikal-docker/issues/73
 if nginx -t 2>&1 >/dev/null | grep -q '\[emerg\] socket() \[::\]:80 failed (97: Address family not supported by protocol)'; then
     echo "$ME: info: Disable IPv6 in configuration"
-    sed -i 's/listen \[::\]:80;/# listen \[::\]:80/' /etc/nginx/conf.d/default.conf
+    sed -i 's/listen \[::\]:8080;/# listen \[::\]:8080/' /etc/nginx/conf.d/default.conf
 fi

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -28,7 +28,7 @@ server {
     return 404;
   }
 
-  # Pass the PHP scripts to FastCGI server listening on /var/run/php-fpm.sock
+  # Pass the PHP scripts to FastCGI server listening on /tmp/php-fpm.sock
   location ~ ^(.+\.php)(.*)$ {
     try_files $fastcgi_script_name =404;
     include        /etc/nginx/fastcgi_params;

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -6,8 +6,8 @@ map $http_x_forwarded_proto $real_scheme {
 }
 
 server {
-  listen 80;
-  listen [::]:80;
+  listen 8080;
+  listen [::]:8080;
   server_name _;
 
   root   /var/www/baikal/html;
@@ -28,12 +28,12 @@ server {
     return 404;
   }
 
-  # Pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+  # Pass the PHP scripts to FastCGI server listening on /var/run/php-fpm.sock
   location ~ ^(.+\.php)(.*)$ {
     try_files $fastcgi_script_name =404;
     include        /etc/nginx/fastcgi_params;
     fastcgi_split_path_info  ^(.+\.php)(.*)$;
-    fastcgi_pass   unix:/var/run/php-fpm.sock;
+    fastcgi_pass   unix:/tmp/php-fpm.sock;
     fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
     fastcgi_param  PATH_INFO        $fastcgi_path_info;
   }

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -7,7 +7,7 @@ ADD https://github.com/sabre-io/Baikal/releases/download/$VERSION/baikal-$VERSIO
 RUN apk add unzip && unzip -q baikal-$VERSION.zip
 
 # Final Docker image
-FROM nginx:1
+FROM docker.io/library/nginx:1
 
 # Install dependencies: PHP & SQLite3
 RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg &&\
@@ -29,13 +29,21 @@ RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
   msmtp msmtp-mta           &&\
   rm -rf /var/lib/apt/lists/* &&\
   sed -i 's/www-data/nginx/' /etc/php/8.5/fpm/pool.d/www.conf &&\
-  sed -i 's/^listen = .*/listen = \/var\/run\/php-fpm.sock/' /etc/php/8.5/fpm/pool.d/www.conf
+  sed -i 's/^listen = .*/listen = \/tmp\/php-fpm.sock/' /etc/php/8.5/fpm/pool.d/www.conf &&\
+  sed -i 's/^error_log = .*/error_log = \/proc\/self\/fd\/2/' /etc/php/8.5/fpm/php-fpm.conf &&\
+  sed -i 's/^pid = .*/pid = \/tmp\/php-fpm.pid/' /etc/php/8.5/fpm/php-fpm.conf
 
 # Add Baikal & nginx configuration
 COPY files/docker-entrypoint.d/*.sh files/docker-entrypoint.d/*.php files/docker-entrypoint.d/nginx/ /docker-entrypoint.d/
 COPY --from=builder --chown=nginx:nginx baikal /var/www/baikal
 COPY files/favicon.ico /var/www/baikal/html
 COPY files/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Rootless compatibility
+RUN sed -i 's,PIDFILE=${PIDFILE:-/run/nginx.pid},PIDFILE=${PIDFILE:-/tmp/nginx.pid},' /etc/init.d/nginx \
+ && sed -i 's,\(/var\)\{0\,1\}/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
+ && chown -R nginx:nginx /var/cache/nginx \
+ && chmod -R g+w /var/cache/nginx
 
 VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -31,19 +31,17 @@ RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
   sed -i 's/www-data/nginx/' /etc/php/8.5/fpm/pool.d/www.conf &&\
   sed -i 's/^listen = .*/listen = \/tmp\/php-fpm.sock/' /etc/php/8.5/fpm/pool.d/www.conf &&\
   sed -i 's/^error_log = .*/error_log = \/proc\/self\/fd\/2/' /etc/php/8.5/fpm/php-fpm.conf &&\
-  sed -i 's/^pid = .*/pid = \/tmp\/php-fpm.pid/' /etc/php/8.5/fpm/php-fpm.conf
+  sed -i 's/^pid = .*/pid = \/tmp\/php-fpm.pid/' /etc/php/8.5/fpm/php-fpm.conf &&\
+  sed -i 's,PIDFILE=${PIDFILE:-/run/nginx.pid},PIDFILE=${PIDFILE:-/tmp/nginx.pid},' /etc/init.d/nginx &&\
+  sed -i 's,\(/var\)\{0\,1\}/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf &&\
+  chown -R nginx:nginx /var/cache/nginx &&\
+  chmod -R g+w /var/cache/nginx
 
 # Add Baikal & nginx configuration
 COPY files/docker-entrypoint.d/*.sh files/docker-entrypoint.d/*.php files/docker-entrypoint.d/nginx/ /docker-entrypoint.d/
 COPY --from=builder --chown=nginx:nginx baikal /var/www/baikal
 COPY files/favicon.ico /var/www/baikal/html
 COPY files/nginx.conf /etc/nginx/conf.d/default.conf
-
-# Rootless compatibility
-RUN sed -i 's,PIDFILE=${PIDFILE:-/run/nginx.pid},PIDFILE=${PIDFILE:-/tmp/nginx.pid},' /etc/init.d/nginx \
- && sed -i 's,\(/var\)\{0\,1\}/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
- && chown -R nginx:nginx /var/cache/nginx \
- && chmod -R g+w /var/cache/nginx
 
 VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific


### PR DESCRIPTION
Tested with rootless and rootful podman with defaults.

Tried to keep the changes as uninvasive as possible. The only default which has to change is the port nginx listens on because port 80 needs privileges to bind. This is why most docker images for things opening ports choose higher ports by default. 