### PR TITLE
Update Baïkal to 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ I follow the same version naming scheme as [Baikal](http://sabre.io/baikal/) the
 
 The following tags support multiple architectures, e.g. `amd64`, `arm32v7`, `arm64v8` and `i386`.
 
-- [`0.11.1`, `0.11.1-nginx`](nginx.dockerfile)
+- [`0.12.1`, `0.12.1-nginx`](nginx.dockerfile)
 
 ## Quick reference
 

--- a/apache.dockerfile
+++ b/apache.dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build, see https://docs.docker.com/develop/develop-images/multistage-build/
 FROM alpine AS builder
 
-ENV VERSION=0.11.1
+ENV VERSION=0.12.1
 
 ADD https://github.com/sabre-io/Baikal/releases/download/$VERSION/baikal-$VERSION.zip .
 RUN apk add unzip && unzip -q baikal-$VERSION.zip

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build, see https://docs.docker.com/develop/develop-images/multistage-build/
 FROM alpine AS builder
 
-ENV VERSION=0.11.1
+ENV VERSION=0.12.1
 
 ADD https://github.com/sabre-io/Baikal/releases/download/$VERSION/baikal-$VERSION.zip .
 RUN apk add unzip && unzip -q baikal-$VERSION.zip


### PR DESCRIPTION
## Summary

Update Baïkal from version `0.11.1` to `0.12.1`.

This change only updates the Baïkal version used to build the Docker images and the tags referenced in `README.md`.

## Why this update is relevant

Baïkal `0.12.0` and `0.12.1` contain several relevant maintenance, compatibility, dependency, and security improvements:

* Fixes an XSS vulnerability that allowed an authenticated user to take over the administration interface by renaming a calendar.
* Updates numerous dependencies, including Twig, Symfony YAML, Bootstrap, jQuery, and `sabre/dav`.
* Updates the bundled `sabre/dav` version to `4.7.1`.
* Fixes deprecation notices when running Baïkal on PHP 8.4 and PHP 8.5.
* Improves the error message shown when the PHP `XMLReader` extension is unavailable.
* Reduces the size of the Baïkal release archive after it grew substantially in version `0.12.0`.

Upstream release notes:

* [Baïkal 0.12.0](https://github.com/sabre-io/Baikal/releases/tag/0.12.0)
* [Baïkal 0.12.1](https://github.com/sabre-io/Baikal/releases/tag/0.12.1)

## Testing

I built the `nginx` Docker image locally using Baïkal `0.12.1` and ran it successfully. The resulting container starts correctly and Baïkal operates as expected.

I also ran the Cypress test suite locally, and all tests passed successfully.

Fixes #11